### PR TITLE
Define `search_fields` for Admin classes

### DIFF
--- a/languages_plus/admin.py
+++ b/languages_plus/admin.py
@@ -7,11 +7,13 @@ class LanguageAdmin(admin.ModelAdmin):
     list_display = ('name_en', 'name_native', 'iso_639_1', 'iso_639_2T', 'iso_639_2B', 'iso_639_2T',
                     'iso_639_3', 'iso_639_6', 'notes')
     list_display_links = ('name_en',)
+    search_fields = ('name_en', 'name_native')
 
 
 class CultureCodeAdmin(admin.ModelAdmin):
     list_display = ('code', 'language', 'country')
     list_display_links = ('code',)
+    search_fields = ('code', 'language', 'country')
 
 admin.site.register(Language, LanguageAdmin)
 admin.site.register(CultureCode, CultureCodeAdmin)


### PR DESCRIPTION
This enables the search box on the admin change list page [1], and can
be used by other apps like django-autocomplete-light [2].

1: https://docs.djangoproject.com/en/1.7/ref/contrib/admin/#django.contrib.admin.ModelAdmin.search_fields
2: https://github.com/yourlabs/django-autocomplete-light/pull/361
