### PR TITLE
Fix Django warning about M2M-relations not being nullable

### DIFF
--- a/languages_plus/migrations/0003_auto_20150803_1140.py
+++ b/languages_plus/migrations/0003_auto_20150803_1140.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('languages_plus', '0002_auto_20141008_0947'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='language',
+            name='countries_spoken',
+            field=models.ManyToManyField(blank=True, to='countries_plus.Country'),
+        ),
+    ]

--- a/languages_plus/models.py
+++ b/languages_plus/models.py
@@ -80,7 +80,7 @@ class Language(models.Model):
     name_other = models.CharField(max_length=50, blank=True)
     family = models.CharField(max_length=50)
     notes = models.CharField(max_length=100, blank=True)
-    countries_spoken = models.ManyToManyField(Country, blank=True, null=True)
+    countries_spoken = models.ManyToManyField(Country, blank=True)
 
     objects = LanguageManager()
 


### PR DESCRIPTION
Fixes the warning appearing in Django 1.8 about many to many relations not being nullable. ([Why?](https://stackoverflow.com/a/18244527))

> WARNINGS:
> languages_plus.Language.countries_spoken: (fields.W340) null has no effect on ManyToManyField.
