### PR TITLE
Django 4: replace ugettext with gettext

### DIFF
--- a/languages_plus/models.py
+++ b/languages_plus/models.py
@@ -6,7 +6,7 @@ from countries_plus.models import Country
 from django.db import models
 from django.db.models import Q
 from django.db.models.query import QuerySet
-from django.utils.translation import ugettext as _
+from django.utils.translation import gettext as _
 
 try:
     from django.utils.encoding import python_2_unicode_compatible

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.1.1
+current_version = 1.2.0
 commit = True
 tag = True
 


### PR DESCRIPTION
deprecated since 3.x, removed with Django 4 -> not working with ugettext