### PR TITLE
remove not required dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,6 @@ classifiers = [
 python = ">=3.8,<4"
 django = ">=3.2,<6"
 django-countries-plus = ">2"
-codecov = "2.1.13"
 
 [tool.poetry.group.test.dependencies]
 coverage = "^7"


### PR DESCRIPTION
I added that dependency by mistake at https://github.com/cordery/django-languages-plus/pull/23 . It shouldn't be required at all.